### PR TITLE
Update client.py

### DIFF
--- a/client.py
+++ b/client.py
@@ -22,7 +22,8 @@ class Synthesizer(object):
 
         params = {'api_id':int(self.api_id),'api_token': self.api_token, 'lang':self.lang}
         try:
-            files={'file':open(opts.text, "rb")}
+            with open(opts.text, "rb") as opts_text:
+                files = {'file': opts_text}
         except IOError as ex:
             logging.error("Problem opening text file {}".format(opts.text))
             raise


### PR DESCRIPTION
The previous version, opening a file and then not closing it is not a good idea and might cause unwanted file locks or, the worst scenario - leaks. Especially if file size is large.   

Besides this, you might want to move `requests.post` piece into the `with open` block - thus, you'll be able to send the file without reading into memory.